### PR TITLE
Use pointer for payload to avoid copylocks

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -347,7 +347,7 @@ func (n *Node) sendMessages() error {
 		return err
 	}
 
-	return n.payloads.MapAndClear(func(peer state.PeerID, payload protobuf.Payload) error {
+	return n.payloads.MapAndClear(func(peer state.PeerID, payload *protobuf.Payload) error {
 		err := n.transport.Send(n.ID, peer, payload)
 		if err != nil {
 			n.logger.Error("error sending message", zap.Error(err))
@@ -358,7 +358,7 @@ func (n *Node) sendMessages() error {
 
 }
 
-func (n *Node) onPayload(sender state.PeerID, payload protobuf.Payload) {
+func (n *Node) onPayload(sender state.PeerID, payload *protobuf.Payload) {
 	// Acks, Requests and Offers are all arrays of bytes as protobuf doesn't allow type aliases otherwise arrays of messageIDs would be nicer.
 	if err := n.onAck(sender, payload.Acks); err != nil {
 		n.logger.Error("error processing acks", zap.Error(err))

--- a/node/payloads.go
+++ b/node/payloads.go
@@ -10,14 +10,14 @@ import (
 type payloads struct {
 	sync.Mutex
 
-	payloads map[state.PeerID]protobuf.Payload
+	payloads map[state.PeerID]*protobuf.Payload
 }
 
 // @todo check in all the functions below that we aren't duplicating stuff
 
 func newPayloads() payloads {
 	return payloads{
-		payloads: make(map[state.PeerID]protobuf.Payload),
+		payloads: make(map[state.PeerID]*protobuf.Payload),
 	}
 }
 
@@ -67,7 +67,7 @@ func (p *payloads) AddMessages(peer state.PeerID, messages ...*protobuf.Message)
 	p.set(peer, payload)
 }
 
-func (p *payloads) MapAndClear(f func(state.PeerID, protobuf.Payload) error) error {
+func (p *payloads) MapAndClear(f func(state.PeerID, *protobuf.Payload) error) error {
 	p.Lock()
 	defer p.Unlock()
 
@@ -79,14 +79,18 @@ func (p *payloads) MapAndClear(f func(state.PeerID, protobuf.Payload) error) err
 	}
 
 	// TODO: this should only be called upon confirmation that the message has been sent
-	p.payloads = make(map[state.PeerID]protobuf.Payload)
+	p.payloads = make(map[state.PeerID]*protobuf.Payload)
 	return nil
 }
 
-func (p *payloads) get(peer state.PeerID) protobuf.Payload {
-	return p.payloads[peer]
+func (p *payloads) get(peer state.PeerID) *protobuf.Payload {
+	payload := p.payloads[peer]
+	if payload == nil {
+		return &protobuf.Payload{}
+	}
+	return payload
 }
 
-func (p *payloads) set(peer state.PeerID, payload protobuf.Payload) {
+func (p *payloads) set(peer state.PeerID, payload *protobuf.Payload) {
 	p.payloads[peer] = payload
 }

--- a/transport/channel_transport.go
+++ b/transport/channel_transport.go
@@ -36,7 +36,7 @@ func (t *ChannelTransport) Watch() Packet {
 	return <-t.in
 }
 
-func (t *ChannelTransport) Send(sender state.PeerID, peer state.PeerID, payload protobuf.Payload) error {
+func (t *ChannelTransport) Send(sender state.PeerID, peer state.PeerID, payload *protobuf.Payload) error {
 	// @todo we can do this better, we put node onlineness into a goroutine where we just stop the nodes for x seconds
 	// outside of this class
 	math.Seed(time.Now().UnixNano())

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -8,11 +8,11 @@ import (
 
 type Packet struct {
 	Sender  state.PeerID
-	Payload protobuf.Payload
+	Payload *protobuf.Payload
 }
 
 // Transport defines an interface allowing for agnostic transport implementations.
 type Transport interface {
 	Watch() Packet
-	Send(sender state.PeerID, peer state.PeerID, payload protobuf.Payload) error
+	Send(sender state.PeerID, peer state.PeerID, payload *protobuf.Payload) error
 }


### PR DESCRIPTION
The master master seems outdated.

This is the diff with the version used in status-go.