### PR TITLE
fix: do not throw error when insert messages.

### DIFF
--- a/store/messagestore_sqlite.go
+++ b/store/messagestore_sqlite.go
@@ -24,7 +24,7 @@ func NewPersistentMessageStore(db *sql.DB) *persistentMessageStore {
 func (p *persistentMessageStore) Add(message *protobuf.Message) error {
 	id := message.ID()
 	_, err := p.db.Exec(
-		`INSERT INTO mvds_messages (id, group_id, timestamp, body)
+		`INSERT OR IGNORE INTO mvds_messages (id, group_id, timestamp, body)
 		VALUES (?, ?, ?, ?)`,
 		id[:],
 		message.GroupId,


### PR DESCRIPTION
When ack is sent but missed, another ack should be sent out when same message comes in. This fix the error and make resent ack possible.
```
Error processing message                 namespace=mvds error="UNIQUE constraint failed: mvds_messages.id"
```