### PR TITLE
feat: clear state that are old enough

### DIFF
--- a/node/node.go
+++ b/node/node.go
@@ -40,6 +40,7 @@ const (
 )
 
 const FreshEventPeriod = 10 // seconds
+const MaxSendCount = 15     // stop resend the message after 15 times (~10 days)
 
 type PeerStatusChangeEvent struct {
 	PeerID    state.PeerID
@@ -222,6 +223,10 @@ func (n *Node) Start(duration time.Duration) {
 				err := n.sendMessages()
 				if err != nil {
 					n.logger.Error("Error sending messages.", zap.Error(err))
+				}
+				err = n.syncState.Clear(MaxSendCount)
+				if err != nil {
+					n.logger.Error("Error clearing sync state.", zap.Error(err))
 				}
 				atomic.AddInt64(&n.epoch, 1)
 				// When a persistent node is used, the epoch needs to be saved.

--- a/state/state.go
+++ b/state/state.go
@@ -27,4 +27,5 @@ type SyncState interface {
 	All(epoch int64) ([]State, error)
 	Map(epoch int64, process func(State) State) error
 	MapWithPeerId(peerID PeerID, process func(State) State) error
+	Clear(count uint64) error
 }

--- a/state/state_memory.go
+++ b/state/state_memory.go
@@ -72,3 +72,19 @@ func (s *memorySyncState) MapWithPeerId(peerID PeerID, process func(State) State
 
 	return nil
 }
+
+func (s *memorySyncState) Clear(count uint64) error {
+	s.Lock()
+	defer s.Unlock()
+
+	var newState []State
+	for _, state := range s.state {
+		if state.SendCount <= count {
+			newState = append(newState, state)
+		}
+	}
+
+	s.state = newState
+
+	return nil
+}

--- a/state/state_sqlite.go
+++ b/state/state_sqlite.go
@@ -220,6 +220,14 @@ func (p *sqliteSyncState) MapWithPeerId(peerID PeerID, process func(State) State
 	return tx.Commit()
 }
 
+func (p *sqliteSyncState) Clear(count uint64) error {
+	_, err := p.db.Exec(
+		`DELETE FROM mvds_states WHERE send_count > ?`,
+		count,
+	)
+	return err
+}
+
 func updateInTx(tx *sql.Tx, state State) error {
 	_, err := tx.Exec(`
 		UPDATE mvds_states


### PR DESCRIPTION
Based on previous discussion with @cammellos, we may want to stop resend for mvds messages that are weeks ago.
The calculation to get the MaxSendCount:

`2^(count-1) * backoffInterval * offsetToSecond /  epochsPerSecond  / 60 / 60 /24` 

- backoffInterval: 30
- offsetToSecond: uint64(time.Second / (300 * time.Millisecond))
- epochsPerSecond: 3.33

`2^14 * 30 * 3 / 3.33 / 60 / 60 / 24 = 5.12 days` delay for 15th resend via mvds. Accumulating the previous attempts, the total delay period is around 10 days. 